### PR TITLE
Fix, restore from Moodle 19 backups

### DIFF
--- a/tab/backup/moodle2/restore_tab_stepslib.php
+++ b/tab/backup/moodle2/restore_tab_stepslib.php
@@ -56,6 +56,18 @@ class restore_tab_activity_structure_step extends restore_activity_structure_ste
         $newitemid = $DB->insert_record('tab', $data);
         // immediately after inserting "activity" record, call this
         $this->apply_activity_instance($newitemid);
+        
+        for ($i=1;$i<=9;$i++) { // assume we have maximum of 8 tabs in the old moodle 19 module
+            $tcdata = new StdClass;
+            $tcdata->id = $oldid;
+            $tcdata->tabid = $newitemid;
+            $tcdata->tabname = $data->{"tab".$i};
+            $tcdata->tabcontent = $data->{"tab".$i."content"};
+            $tcdata->tabcontentorder = $i;
+            $tcdata->timemodified = $data->timemodified;
+            $this->process_tab_content($tcdata);
+
+        }
     }
 
     protected function process_tab_content($data) {


### PR DESCRIPTION
It seems process_tab_content() (moodle23/mod/tab/backup/moodle2/restore_tab_stepslib.php ) was never called while restoring old Moodle 19 backups (Am i right?)

After fix, It seems to work fine. ( Hope I did not miss something ) 
Please review :-)
